### PR TITLE
cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,3 +4,4 @@ project(bruteswim C)
 set(CMAKE_C_STANDARD 23)
 
 add_executable(bruteswim main.c maths.c maths.h types.h trig_table.c mario.c mario.h surface.c surface.h swimming.c swimming.h)
+target_link_libraries(bruteswim m)

--- a/main.c
+++ b/main.c
@@ -8,8 +8,10 @@
 //s16 tri1[3][3] = { {6144, 1024, 6144}, {7168, 2458, 8192}, {6144, 1024, -1535} };
 s16 flo1[3][3] = {{-5375,0,6464},{-5842,128,6248},{-6015,0,6464}};
 s16 flo2[3][3] = { {4144, 1024, 6144}, {4168, 2458, 8192}, {6144, 1024, -1535} };
-s16 numFlos = 2; s16 numCeils = 2;
-s16 *floList[3][3]; s16 *ceilList[3][3];
+s16 numFlos = 2;
+s16 numCeils = 2;
+s16 *floList[3][3];
+s16 *ceilList[3][3];
 
 
 
@@ -26,10 +28,12 @@ s16 faceAngle = 23159;//14;
 
 int main() {
     //! Defining structs
-    struct MarioState *m; m = malloc(sizeof(struct MarioState));
-    struct Surface *floorList[numFlos]; struct Surface *ceilingList[numCeils];
-    struct Surface *floor; struct Surface *ceiling;
-    struct Controller *controller;
+    MarioState *m = (MarioState *) malloc(sizeof(*m));
+    Surface *floorList[numFlos];
+    Surface *ceilingList[numCeils];
+    Surface *floor;
+    Surface *ceiling;
+    Controller *controller;
     //surface = init_surface_data((s16 ***) **triList, 0);
 
     //! add tris to list

--- a/mario.c
+++ b/mario.c
@@ -2,8 +2,8 @@
 #include "maths.h"
 #include <math.h>
 
-void update_mario_joystick_inputs(struct MarioState *m) {
-    struct Controller *controller = m->controller;
+void update_mario_joystick_inputs(MarioState *m) {
+    Controller *controller = m->controller;
     controller->stickMag = sqrtf(controller->stickX * controller->stickX + controller->stickY * controller->stickY);
     f32 mag = ((controller->stickMag / 64.0f) * (controller->stickMag / 64.0f)) * 64.0f;
 

--- a/mario.h
+++ b/mario.h
@@ -3,6 +3,6 @@
 
 #include "types.h"
 
-void update_mario_joystick_inputs(struct MarioState *m);
+void update_mario_joystick_inputs(MarioState *m);
 
 #endif //MARIO_H

--- a/maths.c
+++ b/maths.c
@@ -2,31 +2,26 @@
 #include "types.h"
 
 static u16 atan2_lookup(f32 y, f32 x) {
-    u16 ret;
-
     if (x == 0) {
-        ret = arctan_table[0];
+        return arctan_table[0];
     } else {
-        ret = arctan_table[(s32)(y / x * 1024 + 0.5f)];
+        return arctan_table[(s32)(y / x * 1024 + 0.5f)];
     }
-    return ret;
 }
 s16 atan2s(f32 y, f32 x) {
-    u16 ret;
-
     if (x >= 0) {
         if (y >= 0) {
             if (y >= x) {
-                ret = atan2_lookup(x, y);
+                return atan2_lookup(x, y);
             } else {
-                ret = 0x4000 - atan2_lookup(y, x);
+                return 0x4000 - atan2_lookup(y, x);
             }
         } else {
             y = -y;
             if (y < x) {
-                ret = 0x4000 + atan2_lookup(y, x);
+                return 0x4000 + atan2_lookup(y, x);
             } else {
-                ret = 0x8000 - atan2_lookup(x, y);
+                return 0x8000 - atan2_lookup(x, y);
             }
         }
     } else {
@@ -34,19 +29,18 @@ s16 atan2s(f32 y, f32 x) {
         if (y < 0) {
             y = -y;
             if (y >= x) {
-                ret = 0x8000 + atan2_lookup(x, y);
+                return 0x8000 + atan2_lookup(x, y);
             } else {
-                ret = 0xC000 - atan2_lookup(y, x);
+                return 0xC000 - atan2_lookup(y, x);
             }
         } else {
             if (y < x) {
-                ret = 0xC000 + atan2_lookup(y, x);
+                return 0xC000 + atan2_lookup(y, x);
             } else {
-                ret = -atan2_lookup(x, y);
+                return -atan2_lookup(x, y);
             }
         }
     }
-    return ret;
 }
 /// Copy vector 'src' to 'dest'
 void *vec3f_copy(f32 dest[3], f32 src[3]) {

--- a/surface.h
+++ b/surface.h
@@ -4,10 +4,10 @@
 #include "types.h"
 
 s16 ptInTriangle(f32 p[3], s16 p0[3], s16 p1[3], s16 p2[3]);
-struct Surface *init_surface_data(s16 **vertexData[], s16 triNum);
-f32 check_mario_floor(f32 mPos[3], struct Surface **triList, s16 numTris, struct Surface **pfloor);
-f32 check_mario_ceil(f32 mPos[3], struct Surface **triList, s16 numTris, struct Surface **pceil);
-s32 check_wall_collisions(struct Surface **triList, s16 numTris, struct WallCollisionData *data);
-struct Surface *resolve_and_return_wall_collisions(struct Surface **triList, s16 numTris, f32 pos[3], f32 offset, f32 radius);
-f32 vec3f_find_ceil(pos[3], f32 height, struct Surface **ceil);
+Surface *init_surface_data(s16 **vertexData[], s16 triNum);
+f32 check_mario_floor(f32 mPos[3], Surface **triList, s16 numTris, Surface **pfloor);
+f32 check_mario_ceil(f32 mPos[3], Surface **triList, s16 numTris, Surface **pceil);
+s32 check_wall_collisions(Surface **triList, s16 numTris, WallCollisionData *data);
+Surface *resolve_and_return_wall_collisions(Surface **triList, s16 numTris, f32 pos[3], f32 offset, f32 radius);
+f32 vec3f_find_ceil(pos[3], f32 height, Surface **ceil);
 #endif //SURFACE_H

--- a/swimming.c
+++ b/swimming.c
@@ -4,12 +4,12 @@
 #include "maths.h"
 
 
-s32 swimming_near_surface(struct MarioState *m) {
+s32 swimming_near_surface(MarioState *m) {
 
     return ((f32) m->waterLevel - 80) - m->pos[1] < 400.0f;
 }
 
-f32 get_buoyancy(struct MarioState *m) {
+f32 get_buoyancy(MarioState *m) {
     f32 buoyancy = 0.0f;
 
     if (swimming_near_surface(m)) {
@@ -21,7 +21,7 @@ f32 get_buoyancy(struct MarioState *m) {
     return buoyancy;
 }
 
-void update_swimming_speed(struct MarioState *m, f32 decelThreshold) {
+void update_swimming_speed(MarioState *m, f32 decelThreshold) {
     f32 buoyancy = get_buoyancy(m);
     f32 maxSpeed = 28.0f;
 
@@ -46,7 +46,7 @@ void update_swimming_speed(struct MarioState *m, f32 decelThreshold) {
     m->vel[2] = m->forwardVel * coss(m->faceAngle[0]) * coss(m->faceAngle[1]);
 }
 
-void update_swimming_yaw(struct MarioState *m) {
+void update_swimming_yaw(MarioState *m) {
     s16 targetYawVel = -(s16)(10.0f * m->controller->stickX);
 
     if (targetYawVel > 0) {
@@ -75,7 +75,7 @@ void update_swimming_yaw(struct MarioState *m) {
     m->faceAngle[2] = -m->angleVel[1] * 8;
 }
 
-static void update_swimming_pitch(struct MarioState *m) {
+static void update_swimming_pitch(MarioState *m) {
     s16 targetPitch = -(s16)(252.0f * m->controller->stickY);
 
     s16 pitchVel;

--- a/types.h
+++ b/types.h
@@ -45,24 +45,24 @@ extern f32 sin_table[];
 extern s16 arctan_table[];
 //extern s16 atan2s(f32 y, f32 x);
 
-struct Controller {
+typedef struct Controller {
     /*0x00*/ s16 rawStickX;       //
     /*0x02*/ s16 rawStickY;       //
     /*0x04*/ float stickX;        // [-64, 64] positive is right
     /*0x08*/ float stickY;        // [-64, 64] positive is up
     /*0x0C*/ float stickMag;
-};
+} Controller;
 
-struct WallCollisionData {
+typedef struct WallCollisionData {
     /*0x00*/ f32 x, y, z;
     /*0x0C*/ f32 offsetY;
     /*0x10*/ f32 radius;
     /*0x14*/ u8 filler[2];
     /*0x16*/ s16 numWalls;
     /*0x18*/ struct Surface *walls[4];
-};
+} WallCollisionData;
 
-struct Surface {
+typedef struct Surface {
     /*0x00*/ s16 type;
     /*0x02*/ s16 force;
     /*0x04*/ s8 flags;
@@ -79,8 +79,9 @@ struct Surface {
     } normal;
     /*0x28*/ f32 originOffset;
     /*0x2C*/ struct Object *object;
-};
-struct MarioState {
+} Surface;
+
+typedef struct MarioState {
     u32 action;
     s16 intendedYaw;
     f32 forwardVel;
@@ -96,9 +97,10 @@ struct MarioState {
     f32 pos[3];
     f32 vel[3];
     struct Controller *controller;
-};
-struct Input {
+} MarioState;
+
+typedef struct Input {
     s16 x;
     s16 y;
-};
+} Input;
 #endif //TYPES_H


### PR DESCRIPTION
A few things.
First combining definitions and declarations this can stop a few classes of bugs, one is accidentally using something before you set it to the correct starting value, the second is that it can limit scope and thus you don't accidentally use the same variable for two different things thinking they are different variables.

Fixed a memory leak.

using typedef for the structs so you don't need to keep typing struct everywhere. 

Also, there is no need for a function to only have a single return, it can often be more clear to just return when you know the correct thing. 